### PR TITLE
get.php and getByName.php hardcoded url

### DIFF
--- a/web/get.php
+++ b/web/get.php
@@ -20,6 +20,7 @@
 
 $skuId = isset($_GET['skuId']) ? $_GET['skuId'] : '6PC-00020';
 $lang = isset($_GET['lang']) ? $_GET['lang'] : 'en-us';
+$base_url=$_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['SERVER_NAME'].dirname($_SERVER['REQUEST_URI'].'?').'/';
 require 'lang/core.php';
 require 'shared/get.php';
 require 'shared/style.php';
@@ -69,7 +70,7 @@ foreach ($downList['downloadLinks'] as &$curr) {
     <pre style="margin-top: 1em"><code><?php 
         foreach ($downList['downloadLinks'] as &$iso)
         {
-        echo 'https://mdl-tb.ct8.pl/getDirect.php?fileName='.$iso['fileName']."\n";
+        echo "{$base_url}getDirect.php?fileName=".$iso['fileName']."\n";
         }
     ?></code></pre>
 </div>

--- a/web/getByName.php
+++ b/web/getByName.php
@@ -20,6 +20,7 @@
 
 $fileName = isset($_GET['fileName']) ? $_GET['fileName'] : 'Win7_Pro_SP1_English_x64.iso';
 $lang = isset($_GET['lang']) ? $_GET['lang'] : 'en-us';
+$base_url=$_SERVER['REQUEST_SCHEME'].'://'.$_SERVER['SERVER_NAME'].dirname($_SERVER['REQUEST_URI'].'?').'/';
 require 'lang/core.php';
 require 'shared/get.php';
 require 'shared/style.php';
@@ -59,7 +60,7 @@ echo '<a class="btn btn-primary" href="'.$downList['downloadLink'].'"><span clas
     <h4><span class="glyphicon glyphicon-link" aria-hidden="true"></span> <?php echo $translation['directLinksTitle'];?></h4>
     <p><?php echo $translation['directLinksLine1'];?></p>
     <pre style="margin-top: 1em"><code><?php 
-        echo 'https://mdl-tb.ct8.pl/getDirect.php?fileName='.$downList['fileName']."\n";
+        echo "{$base_url}getDirect.php?fileName=".$downList['fileName']."\n";
     ?></code></pre>
 </div>
 


### PR DESCRIPTION
These files have a hard coded url for a direct link.  I suspect it was to reference to your website.  Since the php files are part of the website repository I changed them to reference the base url.  It is grabbed by combining global REQUEST_SCHEME, SERVER_NAME , and REQUEST_URI.  The last one is stripped a little so that the direct link can be shown correctly.

REQUEST_SCHEME is needed so it shows http(s) based on how the site is currently being accessed.